### PR TITLE
Custom NotFound Controller

### DIFF
--- a/src/NotFoundMvc/ActionInvokerWrapper.cs
+++ b/src/NotFoundMvc/ActionInvokerWrapper.cs
@@ -29,8 +29,17 @@ namespace NotFoundMvc
 
         static void ExecuteNotFoundControllerAction(ControllerContext controllerContext)
         {
-            var controller = new NotFoundController();
-            controller.ExecuteNotFound(controllerContext.RequestContext);
+            IController controller;
+            if (NotFoundHandler.CreateCustomNotFoundController != null)
+            {
+                controller = NotFoundHandler.CreateCustomNotFoundController(controllerContext.RequestContext) ?? new NotFoundController();
+            }
+            else
+            {
+                controller = new NotFoundController();
+            }
+
+            controller.Execute(controllerContext.RequestContext);
         }
 
         bool InvokeActionWith404Catch(ControllerContext controllerContext, string actionName)

--- a/src/NotFoundMvc/ControllerFactoryWrapper.cs
+++ b/src/NotFoundMvc/ControllerFactoryWrapper.cs
@@ -26,7 +26,13 @@ namespace NotFoundMvc
             {
                 if (ex.GetHttpCode() == 404)
                 {
-                    return new NotFoundController();
+                    IController controller = null;
+                    if (NotFoundHandler.CreateCustomNotFoundController != null)
+                    {
+                        controller = NotFoundHandler.CreateCustomNotFoundController(requestContext);
+                    } 
+                    
+                    return controller ?? new NotFoundController();
                 }
 
                 throw;

--- a/src/NotFoundMvc/NotFoundHandler.cs
+++ b/src/NotFoundMvc/NotFoundHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -6,10 +7,25 @@ namespace NotFoundMvc
 {
     public class NotFoundHandler : IHttpHandler
     {
+        public static Func<RequestContext, IController> CreateCustomNotFoundController { get; set; }
+
         public void ProcessRequest(HttpContext context)
         {
             var routeData = new RouteData();
             routeData.Values.Add("controller", "NotFound");
+
+            if (CreateCustomNotFoundController != null)
+            {
+                var ctx = new HttpContextWrapper(context);
+                var requestContext = new RequestContext(ctx, routeData);
+                var controller = CreateCustomNotFoundController(requestContext);
+                if (controller != null)
+                {
+                    controller.Execute(requestContext);
+                    return;
+                }
+            }
+
             var controllerContext = new ControllerContext(new HttpContextWrapper(context), routeData, new FakeController());
             var notFoundViewResult = new NotFoundViewResult();
             notFoundViewResult.ExecuteResult(controllerContext);

--- a/src/NotFoundMvc/Properties/AssemblyInfo.cs
+++ b/src/NotFoundMvc/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]


### PR DESCRIPTION
I choose the Handler for the Function property. This way I was able to use it in the NotFoundHandler, in  the ControllerFactoryWrapper and in the ActionInvokerWrapper and did not have to change the visibility of the latter two.

You can configure your own controller in Global.asax
NotFoundMvc.NotFoundHandler.CreateCustomNotFoundController =
requestContext =>
{
//some sort of logic...
return new MyCustomNotFoundController(requestContext);
//or return null for default functionality
};
