### PR TITLE
Fix for #17 - Interoperability with glimpse

### DIFF
--- a/src/NotFoundMvc/NotFoundController.cs
+++ b/src/NotFoundMvc/NotFoundController.cs
@@ -12,8 +12,11 @@ namespace NotFoundMvc
 
         public void ExecuteNotFound(RequestContext requestContext)
         {
+            Controller controller = new FakeController();
+            ControllerContext context = new ControllerContext(requestContext, controller);
+            controller.ControllerContext = context;
             new NotFoundViewResult().ExecuteResult(
-                new ControllerContext(requestContext, new FakeController())
+                context
             );
         }
 


### PR DESCRIPTION
For the FakeController no controller context has been defined. This
crashed Glimpse.
