### PR TITLE
MVC4, MVC5 Issues with async actions

### DIFF
--- a/package/input/NotFoundMvc.nuspec
+++ b/package/input/NotFoundMvc.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>NotFoundMvc</id>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
         <title>NotFound MVC</title>
         <authors>Andrew Davey</authors>
         <owners>Andrew Davey</owners>

--- a/src/NotFoundMvc/ActionInvokerSelector.cs
+++ b/src/NotFoundMvc/ActionInvokerSelector.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Web.Mvc;
+
+namespace NotFoundMvc
+{
+    static class ActionInvokerSelector
+    {
+        static ActionInvokerSelector()
+        {
+            var mvcVersion = typeof (Controller).Assembly.GetName().Version.Major;
+            Current = mvcVersion <= 3 ? _mvc3Invoker : _mvc4Invoker;
+        }
+
+        private static readonly Func<IActionInvoker, IActionInvoker> _mvc3Invoker =
+           originalActionInvoker => new ActionInvokerWrapper(originalActionInvoker);
+
+        private readonly static Func<IActionInvoker, IActionInvoker> _mvc4Invoker =
+            originalActionInvoker => new NotFoundAsyncControllerActionInvoker();
+
+        public static Func<IActionInvoker, IActionInvoker> Current { get; set; }
+
+    }
+}

--- a/src/NotFoundMvc/ControllerFactoryWrapper.cs
+++ b/src/NotFoundMvc/ControllerFactoryWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using System.Web.SessionState;
@@ -8,7 +9,7 @@ namespace NotFoundMvc
     class ControllerFactoryWrapper : IControllerFactory
     {
         readonly IControllerFactory factory;
-
+        
         public ControllerFactoryWrapper(IControllerFactory factory)
         {
             this.factory = factory;
@@ -38,7 +39,8 @@ namespace NotFoundMvc
             var controllerWithInvoker = controller as Controller;
             if (controllerWithInvoker != null)
             {
-                controllerWithInvoker.ActionInvoker = new ActionInvokerWrapper(controllerWithInvoker.ActionInvoker);
+                controllerWithInvoker.ActionInvoker = 
+                    ActionInvokerSelector.Current(controllerWithInvoker.ActionInvoker);
             }
         }
 

--- a/src/NotFoundMvc/NotFoundAsyncControllerActionInvoker.cs
+++ b/src/NotFoundMvc/NotFoundAsyncControllerActionInvoker.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Web.Mvc;
+using System.Web.Mvc.Async;
+
+namespace NotFoundMvc
+{
+    public class NotFoundAsyncControllerActionInvoker : AsyncControllerActionInvoker
+    {
+        protected override ActionDescriptor FindAction(ControllerContext controllerContext, ControllerDescriptor controllerDescriptor,
+            string actionName)
+        {
+            var result = base.FindAction(controllerContext, controllerDescriptor, actionName);
+            if (result == null)
+            {
+                return new NotFoundActionDescriptor();
+            }
+            return result;
+        }
+    }
+
+    public class NotFoundActionDescriptor : ActionDescriptor
+    {
+        public override object Execute(ControllerContext controllerContext, IDictionary<string, object> parameters)
+        {
+            INotFoundController notFound = NotFoundHandler.CreateNotFoundController(controllerContext.RequestContext);
+            controllerContext.RouteData.Values["action"] = "NotFound";
+            return notFound.NotFound();
+        }
+
+        public override ParameterDescriptor[] GetParameters()
+        {
+            return new ParameterDescriptor[] { };
+        }
+
+        public override string ActionName
+        {
+            get { return "NotFound"; }
+        }
+
+        public override ControllerDescriptor ControllerDescriptor
+        {
+            get { return new ReflectedControllerDescriptor(typeof(NotFoundController)); }
+        }
+    }
+}

--- a/src/NotFoundMvc/NotFoundController.cs
+++ b/src/NotFoundMvc/NotFoundController.cs
@@ -3,7 +3,7 @@ using System.Web.Routing;
 
 namespace NotFoundMvc
 {
-    public class NotFoundController : IController
+    public class NotFoundController : IController, INotFoundController
     {
         public void Execute(RequestContext requestContext)
         {
@@ -17,10 +17,19 @@ namespace NotFoundMvc
             );
         }
 
+        public ActionResult NotFound()
+        {
+            return new NotFoundViewResult();
+        }
+
         // ControllerContext requires an object that derives from ControllerBase.
         // NotFoundController does not do this.
         // So the easiest workaround is this FakeController.
         class FakeController : Controller { }
     }
 
+    public interface INotFoundController: IController
+    {
+        ActionResult NotFound();
+    }
 }

--- a/src/NotFoundMvc/NotFoundHandler.cs
+++ b/src/NotFoundMvc/NotFoundHandler.cs
@@ -7,9 +7,9 @@ namespace NotFoundMvc
 {
     public class NotFoundHandler : IHttpHandler
     {
-        static Func<RequestContext, IController> _createNotFoundController = context => new NotFoundController();
+        static Func<RequestContext, INotFoundController> _createNotFoundController = context => new NotFoundController();
 
-        public static Func<RequestContext, IController> CreateNotFoundController
+        public static Func<RequestContext, INotFoundController> CreateNotFoundController
         {
             get
             {

--- a/src/NotFoundMvc/NotFoundMvc.csproj
+++ b/src/NotFoundMvc/NotFoundMvc.csproj
@@ -47,9 +47,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActionInvokerSelector.cs" />
     <Compile Include="ActionInvokerWrapper.cs" />
     <Compile Include="ControllerFactoryWrapper.cs" />
     <Compile Include="InstallerModule.cs" />
+    <Compile Include="NotFoundAsyncControllerActionInvoker.cs" />
     <Compile Include="NotFoundController.cs" />
     <Compile Include="NotFoundHandler.cs" />
     <Compile Include="NotFoundViewResult.cs" />

--- a/src/NotFoundMvc/Properties/AssemblyInfo.cs
+++ b/src/NotFoundMvc/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
The new async action invoker is used to handle cases where the action is not found. In this case it is not a wrapper! That means it can break you code if you use custom action invokers.