### PR TITLE
fixed `BlockViewHandler` in the sample MVC5 application

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ A view called NotFound is rendered instead of the default ASP.NET error page.
 Use NuGet to install NotFound MVC: https://www.nuget.org/packages/NotFoundMvc
 
 Take a look at the sample application for basic usage. 
-Essentially you just have to add the NotFoundMvc package and optionally alter the NotFound.cshtml view to your app.
+Essentially you just have to add the NotFoundMvc package and optionally alter the NotFound.cshtml view to your app. You also need to change `BlockViewHandler` in `Views\web.config` to use `NotFoundMvc.NotFoundHandler`.
 
 Starting with v1.4, you can plug in an action to be executed on a 404.
 

--- a/src/SampleAppMvc5/Views/Web.config
+++ b/src/SampleAppMvc5/Views/Web.config
@@ -29,7 +29,7 @@
   <system.webServer>
     <handlers>
       <remove name="BlockViewHandler"/>
-      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
+      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="NotFoundMvc.NotFoundHandler" />
     </handlers>
   </system.webServer>
 


### PR DESCRIPTION
The MVC5 sample application doesn't update the `BlockViewHandler` in `Views\web.config` to use NotFoundMvc's handler. This PR fixes this issue.

Setting this handler is important to display our 404 page for direct requests to pages inside the `Views` folder, so I also updated readme.md to emphasize this.